### PR TITLE
Correctly get non-null column values

### DIFF
--- a/agatecharts/charts/bars.py
+++ b/agatecharts/charts/bars.py
@@ -18,8 +18,8 @@ class Bars(Chart):
         return len(self._value_column_names) > 1
 
     def get_x_domain(self, table):
-        x_min = min([min(table.columns[name].get_data_without_nulls()) for name in self._value_column_names])
-        x_max = max([max(table.columns[name].get_data_without_nulls()) for name in self._value_column_names])
+        x_min = min([min(table.columns[name].values_without_nulls()) for name in self._value_column_names])
+        x_max = max([max(table.columns[name].values_without_nulls()) for name in self._value_column_names])
 
         return x_min, x_max
 

--- a/agatecharts/charts/columns.py
+++ b/agatecharts/charts/columns.py
@@ -21,8 +21,8 @@ class Columns(Chart):
         return (None, None)
 
     def get_y_domain(self, table):
-        y_min = min([min(table.columns[name].get_data_without_nulls()) for name in self._value_column_names])
-        y_max = max([max(table.columns[name].get_data_without_nulls()) for name in self._value_column_names])
+        y_min = min([min(table.columns[name].values_without_nulls()) for name in self._value_column_names])
+        y_max = max([max(table.columns[name].values_without_nulls()) for name in self._value_column_names])
 
         return y_min, y_max
 


### PR DESCRIPTION
It appears that the API for `agate.Column` changed the method
name from `Column.get_data_without_nulls()` to
`Column.values_without_nulls()`.  This change needs to be reflected
in this plugin as well.